### PR TITLE
fix: use symbol format for depends_on macos to fix deprecation warning

### DIFF
--- a/Casks/escrcpy.rb
+++ b/Casks/escrcpy.rb
@@ -17,7 +17,7 @@ cask "escrcpy" do
   end
 
   auto_updates false
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "Escrcpy.app"
 


### PR DESCRIPTION
**Fix deprecated `depends_on macos:` string format**

Use symbol format `:catalina` instead of string `">= :catalina"` to resolve Homebrew deprecation warning.